### PR TITLE
Remove unnecessary array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const validator = (schema, opts) => (ctx, next) => {
       schema[key],
       opts
     ).then(validated => {
-      Object.defineProperty(source, [key], {
+      Object.defineProperty(source, key, {
         get() {
           return validated;
         },


### PR DESCRIPTION
Previously, the array would be implicitly cast to a string so `String([key]) === key`.