### PR TITLE
Export Joi

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Just be passed to Joi's validate function as options:
 
 https://github.com/hapijs/joi/blob/master/API.md#validatevalue-schema-options-callback.
 
+### Joi
 ### any
 ### alternatives
 ### array
@@ -223,4 +224,3 @@ MIT © [C.T. Lin](https://github.com/chentsulin/koa-context-validator)
 [coveralls-url]: https://coveralls.io/r/chentsulin/koa-context-validator?branch=master
 [david_img]: https://david-dm.org/chentsulin/koa-context-validator.svg
 [david_site]: https://david-dm.org/chentsulin/koa-context-validator
-

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -7,6 +7,7 @@ import bodyParser from 'koa-bodyparser';
 import mount from 'koa-mount';
 import compose from 'koa-compose';
 import validator, {
+  Joi,
   any,
   alternatives,
   array,
@@ -22,6 +23,7 @@ import validator, {
 } from '../';
 
 it('should export Joi types', () => {
+  expect(Joi).to.exist;
   expect(any).to.exist;
   expect(alternatives).to.exist;
   expect(array).to.exist;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import thenify from 'thenify';
 const validate = thenify(_validate);
 
 export {
+  _validate as Joi,
   any,
   alternatives,
   array,


### PR DESCRIPTION
Joi has several methods (`Joi.required()`, `Joi.lazy()` etc) that are
not re-exported. I believe it's easier to re-export the whole library
than keeping track of all of its methods.

Also, users may prefer to import a single binding than polluting their
module's scope with several imported names.